### PR TITLE
Fix index.html entry script

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,8 +104,7 @@
 <body class="bg-slate-50 text-slate-800">
   <div id="root"></div>
 
-  <!-- Babel + jouw app entrypoint -->
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-  <script type="text/babel" src="./index.js"></script>
+  <!-- App entrypoint -->
+  <script type="module" src="/index.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use a module entrypoint instead of Babel

## Testing
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685069641d3483308bb706bad73ab540